### PR TITLE
mma8x5x: interruption management added

### DIFF
--- a/Makefile.pseudomodules
+++ b/Makefile.pseudomodules
@@ -31,6 +31,7 @@ PSEUDOMODULES += lwip_stats
 PSEUDOMODULES += lwip_tcp
 PSEUDOMODULES += lwip_udp
 PSEUDOMODULES += lwip_udplite
+PSEUDOMODULES += mma8652_int
 PSEUDOMODULES += netdev_default
 PSEUDOMODULES += netif
 PSEUDOMODULES += netstats_l2

--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -73,6 +73,10 @@ ifneq (,$(filter ltc4150,$(USEMODULE)))
     USEMODULE += xtimer
 endif
 
+ifneq (,$(filter mma8652_int,$(USEMODULE)))
+    USEMODULE += mma8652
+endif
+
 ifneq (,$(filter mpu9150,$(USEMODULE)))
     USEMODULE += xtimer
 endif

--- a/drivers/mma8652/include/mma8652_reg.h
+++ b/drivers/mma8652/include/mma8652_reg.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2014 PHYTEC Messtechnik GmbH
+ * Copyright (C) 2016 OTA keys S.A.
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -15,6 +16,7 @@
  * @brief       Register definition for the MMA8652 accelerometer driver.
  *
  * @author      Johann Fischer <j.fischer@phytec.de>
+ * @author      Aurelien Gonce <aurelien.gonce@altran.com>
  *
  */
 
@@ -105,6 +107,7 @@ extern "C"
 #define MMA8652_SYSMOD_FGT_MASK             0x7C
 #define MMA8652_SYSMOD_FGERR                (1 << 7)
 
+#define MMA8652_INT_SOURCE_NONE             (0)
 #define MMA8652_INT_SOURCE_DRDY             (1 << 0)
 #define MMA8652_INT_SOURCE_FF_MT            (1 << 2)
 #define MMA8652_INT_SOURCE_PULSE            (1 << 3)

--- a/drivers/mma8652/mma8652.c
+++ b/drivers/mma8652/mma8652.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2014 PHYTEC Messtechnik GmbH
+ * Copyright (C) 2016 OTA keys S.A.
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -16,12 +17,15 @@
  *
  * @author      Johann Fischer <j.fischer@phytec.de>
  * @author      Peter Kietzmann <peter.kietzmann@haw-hamburg.de>
+ * @author      Aurelien Gonce <aurelien.gonce@altran.com>
  *
  * @}
  */
 
 #include <stdint.h>
 #include <stdbool.h>
+#include <errno.h>
+#include <periph/gpio.h>
 #include "periph/i2c.h"
 #include "mma8652.h"
 #include "mma8652_reg.h"
@@ -103,6 +107,212 @@ int mma8652_init(mma8652_t *dev, i2c_t i2c, uint8_t address, uint8_t dr, uint8_t
 
     return 0;
 }
+
+#ifdef MODULE_MMA8652_INT
+
+enum mma8652_int_id {
+    MMA8652_INT1 = 1,
+    MMA8652_INT2 = 2,
+};
+
+static const uint8_t MMA8x5x_VALID_INT_SRC[MMA8x5x_TYPE_MAX] = {
+    // for MMA8x5x_TYPE_MMA8652
+        (MMA8652_INT_SOURCE_DRDY | MMA8652_INT_SOURCE_FF_MT |
+        MMA8652_INT_SOURCE_PULSE | MMA8652_INT_SOURCE_LNDPRT |
+        MMA8652_INT_SOURCE_TRANS | MMA8652_INT_SOURCE_FIFO |
+        MMA8652_INT_SOURCE_ASLP),
+    // for MMA8x5x_TYPE_MMA8653
+        (MMA8652_INT_SOURCE_DRDY | MMA8652_INT_SOURCE_FF_MT |
+        MMA8652_INT_SOURCE_LNDPRT | MMA8652_INT_SOURCE_ASLP),
+    // for MMA8x5x_TYPE_MMA8451
+        (MMA8652_INT_SOURCE_DRDY | MMA8652_INT_SOURCE_FF_MT |
+        MMA8652_INT_SOURCE_PULSE | MMA8652_INT_SOURCE_LNDPRT |
+        MMA8652_INT_SOURCE_TRANS | MMA8652_INT_SOURCE_FIFO |
+        MMA8652_INT_SOURCE_ASLP),
+    // for MMA8x5x_TYPE_MMA8452
+        (MMA8652_INT_SOURCE_DRDY | MMA8652_INT_SOURCE_FF_MT |
+        MMA8652_INT_SOURCE_PULSE | MMA8652_INT_SOURCE_LNDPRT |
+        MMA8652_INT_SOURCE_TRANS | MMA8652_INT_SOURCE_ASLP),
+    // for MMA8x5x_TYPE_MMA8453
+        (MMA8652_INT_SOURCE_DRDY | MMA8652_INT_SOURCE_FF_MT |
+        MMA8652_INT_SOURCE_PULSE | MMA8652_INT_SOURCE_LNDPRT |
+        MMA8652_INT_SOURCE_TRANS | MMA8652_INT_SOURCE_ASLP)
+};
+
+/**
+ * @brief   Get the right interrupt structure for the given mma8x5x device
+ *          corresponding to the @p id.
+ */
+static inline mma8652_int_t *_get_int(mma8652_t *dev, enum mma8652_int_id id)
+{
+    if (id == MMA8652_INT1) {
+        return &(dev->int1);
+    }
+
+    else {
+        return &(dev->int2);
+    }
+}
+
+static int mma8652_set_int(mma8652_t *dev, uint8_t int_source, enum mma8652_int_id id);
+static int mma8652_add_int(mma8652_t *dev, mma8652_int_t *intx, enum mma8652_int_id id);
+
+int mma8652_init_int(mma8652_t *dev, i2c_t i2c, uint8_t address, uint8_t dr, uint8_t range, uint8_t type,
+                     mma8652_int_t *int1, mma8652_int_t *int2)
+{
+    int res = -1;
+    int ret1 = 0;
+    int ret2 = 0;
+
+    res = mma8652_init(dev, i2c, address, dr, range, type);
+    if (res != 0) {
+        return res;
+    }
+
+    /* mma8652 interrupt structure should be at least initialized to 0 */
+    if (int1 == NULL || int2 == NULL) {
+        return -1;
+    }
+
+    /* At least, one of interruption pin should be in use */
+    if (int1->pin == 0 && int2->pin == 0) {
+        return -1;
+    }
+
+    if(mma8652_add_int(dev, int1, MMA8652_INT1) == -1) {
+        ret1 = -6;
+    }
+
+    if(mma8652_add_int(dev, int2, MMA8652_INT2) == -1) {
+        ret2 = -7;
+    }
+
+    return (ret1 + ret2);
+}
+
+static int mma8652_add_int(mma8652_t *dev, mma8652_int_t *intx, uint8_t id)
+{
+    int res = 0;
+
+    /* pin used */
+    if (intx->pin != 0) {
+        mma8652_int_t *dev_int = _get_int(dev, id);
+
+        dev_int->pin = intx->pin;
+
+        /* used as an interruption */
+        if (intx->cb != NULL) {
+            dev_int->cb = intx->cb;
+            dev_int->arg = intx->arg;
+            gpio_init_int(dev_int->pin, GPIO_IN, GPIO_FALLING, dev_int->cb, dev_int->arg);
+
+            res = mma8652_set_int(dev, intx->source, id);
+            if (res != 0) {
+                res = -1;
+            }
+        }
+        else {
+            gpio_init(dev_int->pin, GPIO_IN);
+        }
+    }
+    return res;
+}
+
+static int mma8652_config_int(mma8652_t *dev)
+{
+    int res = -1;
+    uint8_t config = 0;
+    uint8_t enable = 0;
+
+    /* INT2 is config dominant on INT1 */
+    config = dev->int1.source & ~dev->int2.source;
+    enable = dev->int1.source | dev->int2.source;
+
+    DEBUG("Configure mma8652 interruptions\n");
+
+    DEBUG("Device initialized ");
+    if (dev->initialized != true) {
+        DEBUG("FAILED\n");
+        return -EINVAL;
+    }
+    DEBUG("SUCCESS\n");
+
+    DEBUG("Standby mode ");
+    res = mma8652_set_standby(dev);
+    if (res != 0) {
+        DEBUG("FAILED\n");
+        return -EBUSY;
+    }
+    DEBUG("SUCCESS\n");
+
+    DEBUG("Config interruption ");
+    i2c_acquire(dev->i2c);
+    res = i2c_write_regs(dev->i2c, dev->addr, MMA8652_CTRL_REG5, (char *) &config, 1);
+    i2c_release(dev->i2c);
+    if (res != 1) {
+        DEBUG("FAILED\n");
+        return -EBUSY;
+    }
+    DEBUG("SUCCESS\n");
+
+    DEBUG("Enable interruption ");
+    i2c_acquire(dev->i2c);
+    res = i2c_write_regs(dev->i2c, dev->addr, MMA8652_CTRL_REG4, (char *) &enable, 1);
+    i2c_release(dev->i2c);
+    if (res != 1) {
+        DEBUG("FAILED\n");
+        return -EBUSY;
+    }
+    DEBUG("SUCCESS\n");
+
+    DEBUG("Active mode ");
+    res = mma8652_set_active(dev);
+    if (res != 0) {
+        DEBUG("FAILED\n");
+        return -EBUSY;
+    }
+    DEBUG("SUCCESS\n");
+
+    return 0;
+}
+
+static int mma8652_set_int(mma8652_t *dev, uint8_t int_source, uint8_t id)
+{
+    int res = -1;
+
+    mma8652_int_t *dev_int = _get_int(dev, id);
+
+    if (dev_int->pin == 0 || dev_int->cb == NULL) {
+        return -EINVAL;
+    }
+
+    /* Force to valid value */
+    dev_int->source = int_source & MMA8x5x_VALID_INT_SRC[dev->type];
+    res = mma8652_config_int(dev);
+    if (res != 0) {
+        return res;
+    }
+
+    if (dev_int->source != 0) {
+        gpio_irq_enable(dev_int->pin);
+    }
+    else {
+        gpio_irq_disable(dev_int->pin);
+    }
+
+    return 0;
+}
+
+int mma8652_set_int1(mma8652_t *dev, uint8_t int_source)
+{
+    return mma8652_set_int(dev, int_source, MMA8652_INT1);
+}
+
+int mma8652_set_int2(mma8652_t *dev, uint8_t int_source)
+{
+    return mma8652_set_int(dev, int_source, MMA8652_INT2);
+}
+#endif
 
 int mma8652_set_user_offset(mma8652_t *dev, int8_t x, int8_t y, int8_t z)
 {
@@ -224,4 +434,34 @@ int mma8652_read(mma8652_t *dev, int16_t *x, int16_t *y, int16_t *z, uint8_t *st
     *z = (int32_t)((int16_t)(((int16_t)buf[5] << 8) | buf[6]) >> 4) * 1000 / dev->scale;
 
     return 0;
+}
+
+int mma8682_read_reg(mma8652_t *dev, uint8_t reg, uint8_t *data)
+{
+    int res = -1;
+
+    i2c_acquire(dev->i2c);
+    res = i2c_read_regs(dev->i2c, dev->addr, reg, (char *) data, 1);
+    i2c_release(dev->i2c);
+
+    if (res != 1) {
+        return -1;
+    }
+
+    return 0;
+}
+
+int mma8682_read_interruption_status(mma8652_t *dev, uint8_t *data)
+{
+    return mma8682_read_reg(dev, MMA8652_INT_SOURCE, data);
+}
+
+int mma8682_read_pl_status(mma8652_t *dev, uint8_t *data)
+{
+    return mma8682_read_reg(dev, MMA8652_PL_STATUS, data);
+}
+
+int mma8682_read_freefall_motion_status(mma8652_t *dev, uint8_t *data)
+{
+    return mma8682_read_reg(dev, MMA8652_FF_MT_SRC, data);
 }

--- a/sys/auto_init/saul/auto_init_mma8652.c
+++ b/sys/auto_init/saul/auto_init_mma8652.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2016 Freie Universität Berlin
+ * Copyright (C) 2016 OTA keys S.A.
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -15,6 +16,7 @@
  * @brief       Auto initialization of MMA8652 accelerometer
  *
  * @author      Cenk Gündoğan <mail@cgundogan.de>
+ * @author      Aurelien Gonce <aurelien.gonce@altran.com>
  *
  * @}
  */
@@ -57,7 +59,11 @@ void auto_init_mma8652(void)
 
         DEBUG("[auto_init_saul] initializing mma8652 acc sensor\n");
 
+#ifndef MODULE_MMA8652_INT
         if (mma8652_init(&mma8652_devs[i], p->i2c, p->addr, p->rate, p->scale, p->type) < 0) {
+#else
+        if (mma8652_init_int(&mma8652_devs[i], p->i2c, p->addr, p->rate, p->scale, p->type, p->int1, p->int2) < 0) {
+#endif
             DEBUG("[auto_init_saul] error during initialization\n");
             return;
         }

--- a/tests/driver_mma8652/Makefile
+++ b/tests/driver_mma8652/Makefile
@@ -4,6 +4,7 @@ include ../Makefile.tests_common
 FEATURES_REQUIRED = periph_i2c
 
 USEMODULE += mma8652
+#USEMODULE += mma8652_int
 USEMODULE += xtimer
 
 # set default device parameters in case they are undefined

--- a/tests/driver_mma8652/main.c
+++ b/tests/driver_mma8652/main.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2014 Freie Universität Berlin
  * Copyright (C) 2014 PHYTEC Messtechnik GmbH
+ * Copyright (C) 2016 OTA keys S.A.
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -16,6 +17,7 @@
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  * @author      Johann Fischer <j.fischer@phytec.de>
+ * @author      Aurelien Gonce <aurelien.gonce@altran.com>
  *
  * @}
  */
@@ -34,6 +36,51 @@
 
 #include "xtimer.h"
 #include "mma8652.h"
+#include "mma8652_reg.h"
+
+#ifdef MODULE_MMA8652_INT
+#define MMA8652_INT1_PIN            GPIO_PIN(PORT_B, 0)
+#define MMA8652_INT2_PIN            GPIO_PIN(PORT_B, 1)
+
+#define INT_PIN1                    (0)
+#define INT_PIN2                    (1)
+#define NB_INT_PIN                  (2)
+
+extern void cb_int1(void *arg);
+extern void cb_int2(void *arg);
+
+static mma8652_int_t mma8652_interrupt[NB_INT_PIN] =
+{
+    {
+        .pin = MMA8652_INT1_PIN,
+        .source = MMA8652_INT_SOURCE_DRDY, // MMA8652_INT_SOURCE_NONE
+        .cb = cb_int1,
+        .arg = NULL,
+    },
+    {
+        .pin = MMA8652_INT2_PIN,
+        .source = MMA8652_INT_SOURCE_NONE, // MMA8652_INT_SOURCE_DRDY
+        .cb = cb_int2,
+        .arg = NULL,
+    },
+};
+
+volatile static bool mma8652_semaphore = false;
+
+void cb_int1(void *arg)
+{
+    (void) arg;
+    printf("MMA8652 INT 1\n");
+    mma8652_semaphore = true;
+}
+
+void cb_int2(void *arg)
+{
+    (void) arg;
+    printf("MMA8652 INT 2\n");
+    mma8652_semaphore = true;
+}
+#endif
 
 #define SLEEP       (1000 * 1000U)
 
@@ -46,10 +93,20 @@ int main(void)
     puts("MMA8652 accelerometer driver test application\n");
     printf("Initializing MMA8652 accelerometer at I2C_%i... ", TEST_MMA8652_I2C);
 
+#ifdef MODULE_MMA8652_INT
+    printf("with interruption... ");
+    if (mma8652_init_int(&dev, TEST_MMA8652_I2C, TEST_MMA8652_ADDR,
+                     MMA8652_DATARATE_DEFAULT,
+                     MMA8652_FS_RANGE_DEFAULT,
+                     TEST_MMA8x5x_TYPE,
+                     &(mma8652_interrupt[INT_PIN1]),
+                     &(mma8652_interrupt[INT_PIN2])) == 0) {
+#else
     if (mma8652_init(&dev, TEST_MMA8652_I2C, TEST_MMA8652_ADDR,
                      MMA8652_DATARATE_DEFAULT,
                      MMA8652_FS_RANGE_DEFAULT,
                      TEST_MMA8x5x_TYPE) == 0) {
+#endif
         puts("[OK]\n");
     }
     else {
@@ -70,8 +127,27 @@ int main(void)
     }
 
     while (1) {
+#ifdef MODULE_MMA8652_INT
+        if (mma8652_semaphore == true) {
+            uint8_t int_status = 0;
+            int res = -1;
+
+            res = mma8682_read_interruption_status(&dev, &int_status);
+            if (res != 0) {
+                puts("Read interruption status failed.");
+                return -1;
+            }
+
+            if ((int_status & MMA8652_INT_SOURCE_DRDY) == MMA8652_INT_SOURCE_DRDY) {
+                mma8652_read(&dev, &x, &y, &z, &status);
+                printf("Acceleration, in mg: X: %d Y: %d Z: %d S: %2x\n", x, y, z, status);
+                mma8652_semaphore = false;
+            }
+        }
+#else
         mma8652_read(&dev, &x, &y, &z, &status);
         printf("Acceleration, in mg: X: %d Y: %d Z: %d S: %2x\n", x, y, z, status);
+#endif
         xtimer_usleep(SLEEP);
     }
 


### PR DESCRIPTION
Accelerometer mma8x5x have two interrupt pins configurable.

This PR gives the possibility to use the mma8x5x type device with interruption(s) and configure, one or the two interrupts to the expected source (data ready, freefall/motion, landscape, ...).
- The use of `mma8652_int` module is necessary to call the right init function.
- One or two `mma8652_int_t` structure have to be created to configure the mm8652 device.

This modification could be use with any of MMA devices defined in header file: MMA8652, MMA8653, MMA8451, MMA8452 and MMA8453.

It is `xtimer` and `gpio` module dependent

This PR is based on #5433.
