### PR TITLE
(wrong base)newlib threadsafe: Control allocation through thread flag 

### DIFF
--- a/core/include/thread.h
+++ b/core/include/thread.h
@@ -206,7 +206,7 @@ struct _thread {
                                          to this thread's message queue */
 #endif
 #if defined(MODULE_NEWLIB_THREAD_SAFE) || defined(DOXYGEN)
-    struct _reent newlib_reent;     /**< thread's re-entrent object     */
+    struct _reent newlib_reent;     /**< thread's re-entrant object     */
 #endif
 #if defined(DEVELHELP) || defined(SCHED_TEST_STACK) \
     || defined(MODULE_MPU_STACK_GUARD) || defined(DOXYGEN)

--- a/core/include/thread.h
+++ b/core/include/thread.h
@@ -119,6 +119,10 @@
 #ifndef THREAD_H
 #define THREAD_H
 
+#ifdef MODULE_NEWLIB_THREAD_SAFE
+#include <sys/reent.h>
+#endif
+
 #include "clist.h"
 #include "cib.h"
 #include "msg.h"
@@ -200,6 +204,9 @@ struct _thread {
                                          (thread_t::msg_array), if any  */
     msg_t *msg_array;               /**< memory holding messages sent
                                          to this thread's message queue */
+#endif
+#if defined(MODULE_NEWLIB_THREAD_SAFE) || defined(DOXYGEN)
+    struct _reent newlib_reent;     /**< thread's re-entrent object     */
 #endif
 #if defined(DEVELHELP) || defined(SCHED_TEST_STACK) \
     || defined(MODULE_MPU_STACK_GUARD) || defined(DOXYGEN)

--- a/core/include/thread.h
+++ b/core/include/thread.h
@@ -206,7 +206,7 @@ struct _thread {
                                          to this thread's message queue */
 #endif
 #if defined(MODULE_NEWLIB_THREAD_SAFE) || defined(DOXYGEN)
-    struct _reent newlib_reent;     /**< thread's re-entrant object     */
+    struct _reent *newlib_reent;    /**< thread's re-entrant object     */
 #endif
 #if defined(DEVELHELP) || defined(SCHED_TEST_STACK) \
     || defined(MODULE_MPU_STACK_GUARD) || defined(DOXYGEN)
@@ -321,6 +321,14 @@ struct _thread {
   *        debugging and profiling purposes)
   */
 #define THREAD_CREATE_STACKTEST         (8)
+ /**
+  * @brief Allocate thread local reentrancy structure
+  *
+  * This will be allocated at the top of the stack, near the thread control block.
+  * A thread local reentrancy structure is required for thread safety in certain
+  * libc functions, e.g. stdio in newlib.
+  */
+#define THREAD_CREATE_REENT             (0x10u)
 /** @} */
 
 /**

--- a/core/kernel_init.c
+++ b/core/kernel_init.c
@@ -88,7 +88,7 @@ void kernel_init(void)
 
     thread_create(main_stack, sizeof(main_stack),
             THREAD_PRIORITY_MAIN,
-            THREAD_CREATE_WOUT_YIELD | THREAD_CREATE_STACKTEST,
+            THREAD_CREATE_WOUT_YIELD | THREAD_CREATE_STACKTEST | THREAD_CREATE_REENT,
             main_trampoline, NULL, main_name);
 
     cpu_switch_context_exit();

--- a/core/sched.c
+++ b/core/sched.c
@@ -146,6 +146,10 @@ int __attribute__((used)) sched_run(void)
     mpu_enable();
 #endif
 
+#ifdef MODULE_NEWLIB_THREAD_SAFE
+    _impure_ptr = &(next_thread->newlib_reent);
+#endif
+
     DEBUG("sched_run: done, changed sched_active_thread.\n");
 
     return 1;

--- a/core/sched.c
+++ b/core/sched.c
@@ -147,7 +147,7 @@ int __attribute__((used)) sched_run(void)
 #endif
 
 #ifdef MODULE_NEWLIB_THREAD_SAFE
-    _impure_ptr = &(next_thread->newlib_reent);
+    _impure_ptr = next_thread->newlib_reent;
 #endif
 
     DEBUG("sched_run: done, changed sched_active_thread.\n");

--- a/core/thread.c
+++ b/core/thread.c
@@ -235,6 +235,11 @@ kernel_pid_t thread_create(char *stack, int stacksize, char priority, int flags,
     cb->msg_array = NULL;
 #endif
 
+#ifdef MODULE_NEWLIB_THREAD_SAFE
+    /* initialize the reent context */
+    _REENT_INIT_PTR(&(cb->newlib_reent));
+#endif
+
     sched_num_threads++;
 
     DEBUG("Created thread %s. PID: %" PRIkernel_pid ". Priority: %u.\n", name, cb->pid, priority);

--- a/cpu/cortexm_common/include/cpu_conf_common.h
+++ b/cpu/cortexm_common/include/cpu_conf_common.h
@@ -41,10 +41,18 @@ extern "C" {
 #define THREAD_EXTRA_STACKSIZE_PRINTF   (512)
 #endif
 #ifndef THREAD_STACKSIZE_DEFAULT
+#ifdef MODULE_NEWLIB_THREAD_SAFE
+#define THREAD_STACKSIZE_DEFAULT        (1152)
+#else
 #define THREAD_STACKSIZE_DEFAULT        (1024)
 #endif
+#endif
 #ifndef THREAD_STACKSIZE_IDLE
+#ifdef MODULE_NEWLIB_THREAD_SAFE
+#define THREAD_STACKSIZE_IDLE           (384)
+#else
 #define THREAD_STACKSIZE_IDLE           (256)
+#endif
 #endif
 /** @} */
 

--- a/makefiles/arch/cortexm.inc.mk
+++ b/makefiles/arch/cortexm.inc.mk
@@ -96,6 +96,7 @@ include $(RIOTCPU)/cortexm_common/Makefile.include
 # use the nano-specs of Newlib when available
 USEMODULE += newlib_nano
 export USE_NANO_SPECS = 1
+USEMODULE += newlib_thread_safe
 
 # Avoid overriding the default rule:
 all:

--- a/sys/Makefile.include
+++ b/sys/Makefile.include
@@ -69,6 +69,10 @@ ifneq (,$(filter newlib_syscalls_default,$(USEMODULE)))
   include $(RIOTBASE)/sys/newlib_syscalls_default/Makefile.include
 endif
 
+ifneq (,$(filter newlib_thread_safe,$(USEMODULE)))
+  include $(RIOTBASE)/sys/newlib_thread_safe/Makefile.include
+endif
+
 ifneq (,$(filter arduino,$(USEMODULE)))
   include $(RIOTBASE)/sys/arduino/Makefile.include
 endif

--- a/sys/newlib_thread_safe/Makefile
+++ b/sys/newlib_thread_safe/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/sys/newlib_thread_safe/Makefile.include
+++ b/sys/newlib_thread_safe/Makefile.include
@@ -1,0 +1,1 @@
+UNDEF += $(BINDIR)/newlib_thread_safe/syscalls.o

--- a/sys/newlib_thread_safe/Makefile.include
+++ b/sys/newlib_thread_safe/Makefile.include
@@ -1,1 +1,26 @@
 UNDEF += $(BINDIR)/newlib_thread_safe/syscalls.o
+
+# define the compile test files
+define __has_reent_test
+#include <sys/reent.h>\n
+endef
+
+define __has_reent_small_test
+#include <sys/reent.h>\n
+#ifndef _REENT_SMALL\n
+#error wasting 1KB\n
+#endif\n
+endef
+
+# compile the tests
+__has_reent := $(shell printf "$(__has_reent_test)" | $(CC) -E $(CFLAGS) $(INCLUDES) - > /dev/null 2>&1 ; echo $$?)
+__has_reent_small := $(shell printf "$(__has_reent_small_test)" | $(CC) -E $(CFLAGS) $(INCLUDES) - > /dev/null 2>&1 ; echo $$?)
+
+# check if we use REENT_SMALL
+ifeq (0, $(__has_reent))
+  ifneq (0, $(__has_reent_small))
+    $(error "MODULE_NEWLIB_THREAD_SAFE defined but _REENT_SMALL not defined")
+  endif
+else
+  $(error "MODULE_NEWLIB_THREAD_SAFE defined but <sys/reent.h> not found in toolchain path")
+endif

--- a/sys/newlib_thread_safe/syscalls.c
+++ b/sys/newlib_thread_safe/syscalls.c
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2018 OTA keys S.A.
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     sys_newlib
+ * @{
+ *
+ * @file
+ * @brief       Newlib system calls for thread safety
+ *
+ * @author      Vincent Dupont <vincent@otakeys.com>
+ *
+ * @}
+ */
+
+#include <sys/reent.h>
+
+#include "rmutex.h"
+
+static rmutex_t _env = RMUTEX_INIT;
+static rmutex_t _malloc = RMUTEX_INIT;
+
+void __env_lock(struct _reent *_r)
+{
+    (void)_r;
+
+    rmutex_lock(&_env);
+}
+
+void __env_unlock(struct _reent *_r)
+{
+    (void)_r;
+
+    rmutex_unlock(&_env);
+}
+
+void __malloc_lock(struct _reent *_r)
+{
+    (void)_r;
+
+    rmutex_lock(&_malloc);
+}
+
+void __malloc_unlock(struct _reent *_r)
+{
+    (void)_r;
+
+    rmutex_unlock(&_malloc);
+}

--- a/tests/thread_msg/Makefile
+++ b/tests/thread_msg/Makefile
@@ -4,6 +4,8 @@ BOARD_INSUFFICIENT_MEMORY := nucleo32-f031 nucleo32-f042
 
 DISABLE_MODULE += auto_init
 
+USEMODULE += ps
+
 include $(RIOTBASE)/Makefile.include
 
 test:


### PR DESCRIPTION
Example proof of concept for introducing a thread flag for allocating a thread local reentrancy struct.

See tests/thread_msg for an example printout of thread local vs. global reent pointers.
Threads `main` and `nr3` have thread local reents, threads `nr1`, `nr2` use the global reent struct.