### PR TITLE
stm32/dma: update to fix build with L4, add configuration for one L4 board

### DIFF
--- a/boards/b-l072z-lrwan1/Makefile.dep
+++ b/boards/b-l072z-lrwan1/Makefile.dep
@@ -1,3 +1,5 @@
+FEATURES_REQUIRED += periph_dma
+
 ifneq (,$(filter netdev_default,$(USEMODULE)))
   USEMODULE += sx1276
 endif

--- a/boards/b-l072z-lrwan1/Makefile.features
+++ b/boards/b-l072z-lrwan1/Makefile.features
@@ -1,6 +1,5 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_dma
-FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_spi

--- a/boards/b-l072z-lrwan1/Makefile.features
+++ b/boards/b-l072z-lrwan1/Makefile.features
@@ -1,4 +1,6 @@
 # Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_dma
+FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_spi

--- a/boards/b-l072z-lrwan1/include/periph_conf.h
+++ b/boards/b-l072z-lrwan1/include/periph_conf.h
@@ -69,6 +69,7 @@ static const dma_conf_t dma_config[] = {
 
 #define DMA_NUMOF           (sizeof(dma_config) / sizeof(dma_config[0]))
 #endif
+/** @} */
 
 /**
  * @name    Timer configuration
@@ -171,7 +172,7 @@ static const spi_conf_t spi_config[] = {
 #ifdef MODULE_PERIPH_DMA
         .tx_dma   = 3,
         .tx_dma_chan = 2,
-        .rx_dma   = 4,
+        .rx_dma   = 2,
         .rx_dma_chan = 2,
 #endif
     },

--- a/boards/b-l072z-lrwan1/include/periph_conf.h
+++ b/boards/b-l072z-lrwan1/include/periph_conf.h
@@ -50,6 +50,27 @@ extern "C" {
 /** @} */
 
 /**
+ * @name    DMA streams configuration
+ * @{
+ */
+#ifdef MODULE_PERIPH_DMA
+static const dma_conf_t dma_config[] = {
+    { .stream = 1  }, /* channel 2 */
+    { .stream = 2  }, /* channel 3 */
+    { .stream = 3  }, /* channel 4 */
+    { .stream = 4  }, /* channel 5 */
+    { .stream = 5  }, /* channel 6 */
+};
+
+#define DMA_SHARED_ISR_0            isr_dma1_channel2_3
+#define DMA_SHARED_ISR_0_STREAMS    { 0, 1 } /* Indexes 0 and 1 of dma_config share the same isr */
+#define DMA_SHARED_ISR_1            isr_dma1_channel4_5_6_7
+#define DMA_SHARED_ISR_1_STREAMS    { 2, 3, 4 } /* Indexes 2, 3 and 4 of dma_config share the same isr */
+
+#define DMA_NUMOF           (sizeof(dma_config) / sizeof(dma_config[0]))
+#endif
+
+/**
  * @name    Timer configuration
  * @{
  */
@@ -84,6 +105,10 @@ static const uart_conf_t uart_config[] = {
         .irqn       = USART2_IRQn,
         .type       = STM32_USART,
         .clk_src    = 0, /* Use APB clock */
+#ifdef MODULE_PERIPH_DMA
+        .dma        = 2,
+        .dma_chan   = 4,
+#endif
     },
     {
         .dev        = USART1,
@@ -96,6 +121,10 @@ static const uart_conf_t uart_config[] = {
         .irqn       = USART1_IRQn,
         .type       = STM32_USART,
         .clk_src    = 0, /* Use APB clock */
+#ifdef MODULE_PERIPH_DMA
+        .dma        = 0,
+        .dma_chan   = 3,
+#endif
     },
 };
 
@@ -138,7 +167,13 @@ static const spi_conf_t spi_config[] = {
         .cs_pin   = GPIO_UNDEF,
         .af       = GPIO_AF0,
         .rccmask  = RCC_APB1ENR_SPI2EN,
-        .apbbus   = APB1
+        .apbbus   = APB1,
+#ifdef MODULE_PERIPH_DMA
+        .tx_dma   = 3,
+        .tx_dma_chan = 2,
+        .rx_dma   = 4,
+        .rx_dma_chan = 2,
+#endif
     },
     {
         .dev      = SPI1, /* connected to SX1276 */
@@ -148,7 +183,13 @@ static const spi_conf_t spi_config[] = {
         .cs_pin   = GPIO_UNDEF,
         .af       = GPIO_AF0,
         .rccmask  = RCC_APB2ENR_SPI1EN,
-        .apbbus   = APB2
+        .apbbus   = APB2,
+#ifdef MODULE_PERIPH_DMA
+        .tx_dma   = 1,
+        .tx_dma_chan = 1,
+        .rx_dma   = 0,
+        .rx_dma_chan = 1,
+#endif
     },
 };
 

--- a/boards/b-l475e-iot01a/Makefile.dep
+++ b/boards/b-l475e-iot01a/Makefile.dep
@@ -1,3 +1,5 @@
+FEATURES_REQUIRED += periph_dma
+
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
   USEMODULE += hts221

--- a/boards/b-l475e-iot01a/Makefile.features
+++ b/boards/b-l475e-iot01a/Makefile.features
@@ -1,4 +1,5 @@
 # Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_dma
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_spi

--- a/boards/b-l475e-iot01a/include/periph_conf.h
+++ b/boards/b-l475e-iot01a/include/periph_conf.h
@@ -70,6 +70,33 @@ extern "C" {
 /** @} */
 
 /**
+ * @name    DMA streams configuration
+ * @{
+ */
+#ifdef MODULE_PERIPH_DMA
+static const dma_conf_t dma_config[] = {
+    { .stream = 1 },
+    { .stream = 2 },
+    { .stream = 3 },
+    { .stream = 4 },
+    { .stream = 5 },
+    { .stream = 6 },
+    { .stream = 7 },
+};
+
+#define DMA_0_ISR  isr_dma1_channel1
+#define DMA_1_ISR  isr_dma1_channel2
+#define DMA_2_ISR  isr_dma1_channel3
+#define DMA_3_ISR  isr_dma1_channel4
+#define DMA_4_ISR  isr_dma1_channel5
+#define DMA_5_ISR  isr_dma1_channel6
+#define DMA_6_ISR  isr_dma1_channel7
+
+#define DMA_NUMOF           (sizeof(dma_config) / sizeof(dma_config[0]))
+#endif
+/** @} */
+
+/**
  * @name    Timer configuration
  * @{
  */
@@ -104,9 +131,9 @@ static const uart_conf_t uart_config[] = {
         .irqn       = USART1_IRQn,
         .type       = STM32_USART,
         .clk_src    = 0, /* Use APB clock */
-#ifdef UART_USE_DMA
-        .dma_stream = 6,
-        .dma_chan   = 4
+#ifdef MODULE_PERIPH_DMA
+        .dma        = 1,
+        .dma_chan   = 1
 #endif
     },
     {
@@ -120,9 +147,9 @@ static const uart_conf_t uart_config[] = {
         .irqn       = UART4_IRQn,
         .type       = STM32_USART,
         .clk_src    = 0, /* Use APB clock */
-#ifdef UART_USE_DMA
-        .dma_stream = 5,
-        .dma_chan   = 4
+#ifdef MODULE_PERIPH_DMA
+        .dma        = 1,
+        .dma_chan   = 2
 #endif
     }
 };
@@ -186,7 +213,13 @@ static const spi_conf_t spi_config[] = {
         .cs_pin   = GPIO_UNDEF,
         .af       = GPIO_AF5,
         .rccmask  = RCC_APB2ENR_SPI1EN,
-        .apbbus   = APB2
+        .apbbus   = APB2,
+#ifdef MODULE_PERIPH_DMA
+        .tx_dma   = 2,
+        .tx_dma_chan = 3,
+        .rx_dma   = 3,
+        .rx_dma_chan = 4,
+#endif
     }
 };
 

--- a/boards/nucleo-f091rc/Makefile.dep
+++ b/boards/nucleo-f091rc/Makefile.dep
@@ -1,1 +1,3 @@
+FEATURES_REQUIRED += periph_dma
+
 include $(RIOTBOARD)/common/nucleo/Makefile.dep

--- a/boards/nucleo-f091rc/Makefile.features
+++ b/boards/nucleo-f091rc/Makefile.features
@@ -1,7 +1,6 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_dma
-FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc

--- a/boards/nucleo-f091rc/Makefile.features
+++ b/boards/nucleo-f091rc/Makefile.features
@@ -1,5 +1,7 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_dma
+FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc

--- a/boards/nucleo-f091rc/include/periph_conf.h
+++ b/boards/nucleo-f091rc/include/periph_conf.h
@@ -57,6 +57,22 @@ extern "C" {
 /** @} */
 
 /**
+ * @name    DMA streams configuration
+ * @{
+ */
+#ifdef MODULE_PERIPH_DMA
+static const dma_conf_t dma_config[] = {
+    { .stream = 1  },
+    { .stream = 2  },
+};
+
+#define DMA_SHARED_ISR_0            isr_dma1_ch2_3_dma2_ch1_2
+#define DMA_SHARED_ISR_0_STREAMS    { 0, 1 } /* Indexes 0 and 1 of dma_config share the same isr */
+
+#define DMA_NUMOF           (sizeof(dma_config) / sizeof(dma_config[0]))
+#endif
+
+/**
  * @name   Timer configuration
  * @{
  */
@@ -88,7 +104,11 @@ static const uart_conf_t uart_config[] = {
         .rx_af      = GPIO_AF1,
         .tx_af      = GPIO_AF1,
         .bus        = APB1,
-        .irqn       = USART2_IRQn
+        .irqn       = USART2_IRQn,
+#ifdef MODULE_PERIPH_DMA
+        .dma        = 0,
+        .dma_chan   = 0x9,
+#endif
     },
     {
         .dev        = USART1,
@@ -98,7 +118,11 @@ static const uart_conf_t uart_config[] = {
         .rx_af      = GPIO_AF1,
         .tx_af      = GPIO_AF1,
         .bus        = APB2,
-        .irqn       = USART1_IRQn
+        .irqn       = USART1_IRQn,
+#ifdef MODULE_PERIPH_DMA
+        .dma        = 0,
+        .dma_chan   = 0x8,
+#endif
     },
     {
         .dev        = USART3,
@@ -108,7 +132,11 @@ static const uart_conf_t uart_config[] = {
         .rx_af      = GPIO_AF1,
         .tx_af      = GPIO_AF1,
         .bus        = APB1,
-        .irqn       = USART3_8_IRQn
+        .irqn       = USART3_8_IRQn,
+#ifdef MODULE_PERIPH_DMA
+        .dma        = 0,
+        .dma_chan   = 0xA,
+#endif
     },
 };
 
@@ -153,7 +181,13 @@ static const spi_conf_t spi_config[] = {
         .cs_pin   = GPIO_PIN(PORT_B, 6),
         .af       = GPIO_AF0,
         .rccmask  = RCC_APB2ENR_SPI1EN,
-        .apbbus   = APB2
+        .apbbus   = APB2,
+#ifdef MODULE_PERIPH_DMA
+        .tx_dma   = 0,
+        .tx_dma_chan = 0,
+        .rx_dma   = 1,
+        .rx_dma_chan = 0,
+#endif
     }
 };
 

--- a/boards/nucleo-f091rc/include/periph_conf.h
+++ b/boards/nucleo-f091rc/include/periph_conf.h
@@ -183,9 +183,9 @@ static const spi_conf_t spi_config[] = {
         .rccmask  = RCC_APB2ENR_SPI1EN,
         .apbbus   = APB2,
 #ifdef MODULE_PERIPH_DMA
-        .tx_dma   = 0,
+        .tx_dma   = 1,
         .tx_dma_chan = 0,
-        .rx_dma   = 1,
+        .rx_dma   = 0,
         .rx_dma_chan = 0,
 #endif
     }

--- a/cpu/stm32_common/include/periph_cpu_common.h
+++ b/cpu/stm32_common/include/periph_cpu_common.h
@@ -567,7 +567,7 @@ void dma_init(void);
  *
  * @return < 0 on error, the number of transfered bytes otherwise
  */
-int dma_transfer(dma_t dma, int chan, const void *src, void *dst, size_t len,
+int dma_transfer(dma_t dma, int chan, const volatile void *src, volatile void *dst, size_t len,
                  dma_mode_t mode, uint8_t flags);
 
 /**
@@ -638,7 +638,7 @@ void dma_wait(dma_t dma);
  *
  * @return < 0 on error, 0 on success
  */
-int dma_configure(dma_t dma, int chan, const void *src, void *dst, size_t len,
+int dma_configure(dma_t dma, int chan, const volatile void *src, volatile void *dst, size_t len,
                   dma_mode_t mode, uint8_t flags);
 
 #endif /* MODULE_PERIPH_DMA */

--- a/cpu/stm32_common/include/periph_cpu_common.h
+++ b/cpu/stm32_common/include/periph_cpu_common.h
@@ -241,7 +241,29 @@ typedef enum {
  * @brief   DMA configuration
  */
 typedef struct {
-    int stream;            /**< DMA stream */
+    /** DMA stream on stm32f2/4/7, channel on others
+     * STM32F2/4/7:
+     *  - 0: DMA1 / Stream0
+     *  - 1: DMA1 / Stream1
+     *  - ...
+     *  - 7: DMA1 / Stream7
+     *  - 8: DAM2 / Stream0
+     *  - ...
+     *  - 15: DMA2 / Stream7
+     * STM32F0/1/L0/1/4:
+     *  - 0: DMA1 / Channel1
+     *  - ...
+     *  - 4: DMA1 / Channel5
+     *  - ...
+     *  - 6: DMA1 / Channel7
+     *  - 7: Reserved
+     *  - 8: DMA2 / Channel1
+     *  - ...
+     *  - 12: DMA2 / Channel5
+     *  - ...
+     *  - 14: DMA2 / Channel7
+     */
+    int stream;
 } dma_conf_t;
 
 /**
@@ -536,7 +558,7 @@ void dma_init(void);
  * function which configure, start, wait and stop a DMA transfer.
  *
  * @param[in]  dma     logical DMA stream
- * @param[in]  chan    DMA channel
+ * @param[in]  chan    DMA channel (on stm32f2/4/7, CxS or unused on others)
  * @param[in]  src     source buffer
  * @param[out] dst     destination buffer
  * @param[in]  len     length to transfer
@@ -619,144 +641,6 @@ void dma_wait(dma_t dma);
 int dma_configure(dma_t dma, int chan, const void *src, void *dst, size_t len,
                   dma_mode_t mode, uint8_t flags);
 
-/**
- * @brief   Get DMA base register
- *
- * For simplifying DMA stream handling, we map the DMA channels transparently to
- * one integer number, such that DMA1 stream0 equals 0, DMA2 stream0 equals 8,
- * DMA2 stream 7 equals 15 and so on.
- *
- * @param[in] stream    physical DMA stream
- */
-static inline DMA_TypeDef *dma_base(int stream)
-{
-    return (stream < 8) ? DMA1 : DMA2;
-}
-
-/**
- * @brief   Power on the DMA device the given stream belongs to
- *
- * @param[in] stream    physical DMA stream
- */
-static inline void dma_poweron(int stream)
-{
-    if (stream < 8) {
-        periph_clk_en(AHB1, RCC_AHB1ENR_DMA1EN);
-    }
-    else {
-        periph_clk_en(AHB1, RCC_AHB1ENR_DMA2EN);
-    }
-}
-
-/**
- * @brief   Get the DMA stream base address
- *
- * @param[in] stream    physical DMA stream
- *
- * @return  base address for the selected DMA stream
- */
-static inline DMA_Stream_TypeDef *dma_stream(int stream)
-{
-    uint32_t base = (uint32_t)dma_base(stream);
-
-    return (DMA_Stream_TypeDef *)(base + (0x10 + (0x18 * (stream & 0x7))));
-}
-
-/**
- * @brief   Select high or low DMA interrupt register based on stream number
- *
- * @param[in] stream    physical DMA stream
- *
- * @return  0 for streams 0-3, 1 for streams 3-7
- */
-static inline int dma_hl(int stream)
-{
-    return ((stream & 0x4) >> 2);
-}
-
-/**
- * @brief   Get the interrupt flag clear bit position in the DMA LIFCR register
- *
- * @param[in] stream    physical DMA stream
- */
-static inline uint32_t dma_ifc(int stream)
-{
-    switch (stream & 0x3) {
-        case 0:
-            return (1 << 5);
-        case 1:
-            return (1 << 11);
-        case 2:
-            return (1 << 21);
-        case 3:
-            return (1 << 27);
-        default:
-            return 0;
-    }
-}
-
-/**
- * @brief   Enable the interrupt of a given stream
- *
- * @param[in] stream    physical DMA stream
- */
-static inline void dma_isr_enable(int stream)
-{
-    if (stream < 7) {
-        NVIC_EnableIRQ((IRQn_Type)((int)DMA1_Stream0_IRQn + stream));
-    }
-    else if (stream == 7) {
-        NVIC_EnableIRQ(DMA1_Stream7_IRQn);
-    }
-    else if (stream < 13) {
-        NVIC_EnableIRQ((IRQn_Type)((int)DMA2_Stream0_IRQn + (stream - 8)));
-    }
-    else if (stream < 16) {
-        NVIC_EnableIRQ((IRQn_Type)((int)DMA2_Stream5_IRQn + (stream - 13)));
-    }
-}
-
-/**
- * @brief   Disable the interrupt of a given stream
- *
- * @param[in] stream    physical DMA stream
- */
-static inline void dma_isr_disable(int stream)
-{
-    if (stream < 7) {
-        NVIC_DisableIRQ((IRQn_Type)((int)DMA1_Stream0_IRQn + stream));
-    }
-    else if (stream == 7) {
-        NVIC_DisableIRQ(DMA1_Stream7_IRQn);
-    }
-    else if (stream < 13) {
-        NVIC_DisableIRQ((IRQn_Type)((int)DMA2_Stream0_IRQn + (stream - 8)));
-    }
-    else if (stream < 16) {
-        NVIC_DisableIRQ((IRQn_Type)((int)DMA2_Stream5_IRQn + (stream - 13)));
-    }
-}
-
-/**
- * @brief   Clear the interrupt of a given stream
- *
- * @param[in] stream    physical DMA stream
- */
-static inline void dma_isr_clear(int stream)
-{
-    if (stream < 7) {
-        NVIC_ClearPendingIRQ((IRQn_Type)((int)DMA1_Stream0_IRQn + stream));
-    }
-    else if (stream == 7) {
-        NVIC_ClearPendingIRQ((IRQn_Type)DMA1_Stream7_IRQn);
-    }
-    else if (stream < 13) {
-        NVIC_ClearPendingIRQ((IRQn_Type)((int)DMA2_Stream0_IRQn + (stream - 8)));
-    }
-    else if (stream < 16) {
-        NVIC_ClearPendingIRQ((IRQn_Type)((int)DMA2_Stream5_IRQn + (stream - 13)));
-    }
-}
 #endif /* MODULE_PERIPH_DMA */
 
 #ifdef __cplusplus

--- a/cpu/stm32_common/include/periph_cpu_common.h
+++ b/cpu/stm32_common/include/periph_cpu_common.h
@@ -629,7 +629,7 @@ void dma_wait(dma_t dma);
  * @brief   Configure a DMA stream for a new transfer
  *
  * @param[in]  dma     logical DMA stream
- * @param[in]  chan    DMA channel
+ * @param[in]  chan    DMA channel (on stm32f2/4/7, CxS or unused on others)
  * @param[in]  src     source buffer
  * @param[out] dst     destination buffer
  * @param[in]  len     length to transfer

--- a/cpu/stm32_common/periph/dma.c
+++ b/cpu/stm32_common/periph/dma.c
@@ -47,13 +47,19 @@
 #define DMA_EN                  DMA_SxCR_EN
 #else
 #define STM32_DMA_Stream_Type   DMA_Channel_TypeDef
+#if CPU_FAM_STM32L4
+#define CLOCK                   AHB1
+#define RCC_MASK_DMA1           RCC_AHB1ENR_DMA1EN
+#define RCC_MASK_DMA2           RCC_AHB1ENR_DMA2EN
+#else /* CPU_FAM_STM32L4 */
 #define CLOCK                   AHB
+#define RCC_MASK_DMA1           RCC_AHBENR_DMAEN
+#define RCC_MASK_DMA2           RCC_AHBENR_DMA2EN
+#endif /* CPU_FAM_STM32L4 */
 #define PERIPH_ADDR             CPAR
 #define MEM_ADDR                CMAR
 #define NDTR_REG                CNDTR
 #define CONTROL_REG             CCR
-#define RCC_MASK_DMA1           RCC_AHBENR_DMAEN
-#define RCC_MASK_DMA2           RCC_AHBENR_DMA2EN
 #define DMA_STREAM_IT_MASK      (DMA_IFCR_CGIF1 | DMA_IFCR_CTCIF1 | \
                                  DMA_IFCR_CHTIF1 | DMA_IFCR_CTEIF1)
 #define DMA_EN                  DMA_CCR_EN

--- a/cpu/stm32_common/periph/dma.c
+++ b/cpu/stm32_common/periph/dma.c
@@ -299,7 +299,7 @@ static void dma_poweron(int stream)
 }
 
 
-int dma_transfer(dma_t dma, int chan, const void *src, void *dst, size_t len,
+int dma_transfer(dma_t dma, int chan, const volatile void *src, volatile void *dst, size_t len,
                  dma_mode_t mode, uint8_t flags)
 {
     int ret = dma_configure(dma, chan, src, dst, len, mode, flags);
@@ -335,7 +335,7 @@ void dma_release(dma_t dma)
     mutex_unlock(&dma_ctx[dma].conf_lock);
 }
 
-int dma_configure(dma_t dma, int chan, const void *src, void *dst, size_t len,
+int dma_configure(dma_t dma, int chan, const volatile void *src, volatile void *dst, size_t len,
                   dma_mode_t mode, uint8_t flags)
 {
     assert(src != NULL);
@@ -381,7 +381,8 @@ int dma_configure(dma_t dma, int chan, const void *src, void *dst, size_t len,
     stream->FCR = 0;
 #else
 #if defined(DMA_CSELR_C1S) || defined(DMA1_CSELR_DEFAULT)
-    dma_req(stream_n)->CSELR = (chan & 0xF) << ((stream_n & 0x7) << 2);
+    dma_req(stream_n)->CSELR &= ~((0xF) << ((stream_n & 0x7) << 2));
+    dma_req(stream_n)->CSELR |= (chan & 0xF) << ((stream_n & 0x7) << 2);
 #endif
     stream->CCR = width << DMA_CCR_MSIZE_Pos | width << DMA_CCR_PSIZE_Pos |
                   inc_periph << DMA_CCR_PINC_Pos | inc_mem << DMA_CCR_MINC_Pos |

--- a/cpu/stm32_common/periph/spi.c
+++ b/cpu/stm32_common/periph/spi.c
@@ -169,19 +169,19 @@ static void _transfer_dma(spi_t bus, const void *out, void *in, size_t len)
 
     if (!out) {
         dma_configure(spi_config[bus].tx_dma, spi_config[bus].tx_dma_chan, &tmp,
-                      (void *)&(dev(bus)->DR), len, DMA_MEM_TO_PERIPH, 0);
+                      &(dev(bus)->DR), len, DMA_MEM_TO_PERIPH, 0);
     }
     else {
         dma_configure(spi_config[bus].tx_dma, spi_config[bus].tx_dma_chan, out,
-                      (void *)&(dev(bus)->DR), len, DMA_MEM_TO_PERIPH, DMA_INC_SRC_ADDR);
+                      &(dev(bus)->DR), len, DMA_MEM_TO_PERIPH, DMA_INC_SRC_ADDR);
     }
     if (!in) {
         dma_configure(spi_config[bus].rx_dma, spi_config[bus].rx_dma_chan,
-                      (void *)&(dev(bus)->DR), &tmp, len, DMA_PERIPH_TO_MEM, 0);
+                      &(dev(bus)->DR), &tmp, len, DMA_PERIPH_TO_MEM, 0);
     }
     else {
         dma_configure(spi_config[bus].rx_dma, spi_config[bus].rx_dma_chan,
-                      (void *)&(dev(bus)->DR), in, len, DMA_PERIPH_TO_MEM, DMA_INC_DST_ADDR);
+                      &(dev(bus)->DR), in, len, DMA_PERIPH_TO_MEM, DMA_INC_DST_ADDR);
     }
     dev(bus)->CR2 |= SPI_CR2_TXDMAEN | SPI_CR2_RXDMAEN;
 

--- a/cpu/stm32_common/periph/uart.c
+++ b/cpu/stm32_common/periph/uart.c
@@ -204,7 +204,7 @@ static inline void uart_init_lpuart(uart_t uart, uint32_t baudrate)
 
 static inline void send_byte(uart_t uart, uint8_t byte)
 {
-    while (!(dev(uart)->ISR_REG & USART_ISR_TXE)) {}
+    while (!(dev(uart)->ISR_REG & ISR_TXE)) {}
     dev(uart)->TDR_REG = byte;
 }
 

--- a/cpu/stm32_common/periph/uart.c
+++ b/cpu/stm32_common/periph/uart.c
@@ -34,6 +34,21 @@
 #include "periph/gpio.h"
 #include "pm_layered.h"
 
+#if defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32L0) \
+    || defined(CPU_FAM_STM32F3) || defined(CPU_FAM_STM32L4) \
+    || defined(CPU_FAM_STM32F7)
+#define ISR_REG     ISR
+#define ISR_TXE     USART_ISR_TXE
+#define ISR_TC      USART_ISR_TC
+#define TDR_REG     TDR
+#else
+#define ISR_REG     SR
+#define ISR_TXE     USART_SR_TXE
+#define ISR_TC      USART_SR_TC
+#define TDR_REG     DR
+
+#endif
+
 #define RXENABLE            (USART_CR1_RE | USART_CR1_RXNEIE)
 
 /**
@@ -189,26 +204,13 @@ static inline void uart_init_lpuart(uart_t uart, uint32_t baudrate)
 
 static inline void send_byte(uart_t uart, uint8_t byte)
 {
-#if defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32L0) \
-    || defined(CPU_FAM_STM32F3) || defined(CPU_FAM_STM32L4) \
-    || defined(CPU_FAM_STM32F7)
-    while (!(dev(uart)->ISR & USART_ISR_TXE)) {}
-    dev(uart)->TDR = byte;
-#else
-    while (!(dev(uart)->SR & USART_SR_TXE)) {}
-    dev(uart)->DR = byte;
-#endif
+    while (!(dev(uart)->ISR_REG & USART_ISR_TXE)) {}
+    dev(uart)->TDR_REG = byte;
 }
 
 static inline void wait_for_tx_complete(uart_t uart)
 {
-#if defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32L0) \
-    || defined(CPU_FAM_STM32F3) || defined(CPU_FAM_STM32L4) \
-    || defined(CPU_FAM_STM32F7)
-    while (!(dev(uart)->ISR & USART_ISR_TC)) {}
-#else
-    while (!(dev(uart)->SR & USART_SR_TC)) {}
-#endif
+    while (!(dev(uart)->ISR_REG & ISR_TC)) {}
 }
 
 void uart_write(uart_t uart, const uint8_t *data, size_t len)
@@ -248,7 +250,7 @@ void uart_write(uart_t uart, const uint8_t *data, size_t len)
             dma_acquire(uart_config[uart].dma);
             dev(uart)->CR3 |= USART_CR3_DMAT;
             dma_transfer(uart_config[uart].dma, uart_config[uart].dma_chan, data,
-                         (void *)&dev(uart)->DR, len, DMA_MEM_TO_PERIPH, DMA_INC_SRC_ADDR);
+                         (void *)&dev(uart)->TDR_REG, len, DMA_MEM_TO_PERIPH, DMA_INC_SRC_ADDR);
             dma_release(uart_config[uart].dma);
 
             /* make sure the function is synchronous by waiting for the transfer to

--- a/drivers/cc110x/cc110x-spi.c
+++ b/drivers/cc110x/cc110x-spi.c
@@ -33,7 +33,6 @@
 #include "periph/spi.h"
 
 #include "xtimer.h"
-#include "irq.h"
 
 #define SPI_CLK         SPI_CLK_5MHZ
 #define SPI_MODE        SPI_MODE_0
@@ -82,23 +81,18 @@ void cc110x_cs(cc110x_t *dev)
 
 void cc110x_writeburst_reg(cc110x_t *dev, uint8_t addr, const char *src, uint8_t count)
 {
-    unsigned int cpsr;
     lock(dev);
-    cpsr = irq_disable();
     cc110x_cs(dev);
     spi_transfer_regs(dev->params.spi, SPI_CS_UNDEF,
                       (addr | CC110X_WRITE_BURST), src, NULL, count);
     gpio_set(dev->params.cs);
-    irq_restore(cpsr);
     spi_release(dev->params.spi);
 }
 
 void cc110x_readburst_reg(cc110x_t *dev, uint8_t addr, char *buffer, uint8_t count)
 {
     int i = 0;
-    unsigned int cpsr;
     lock(dev);
-    cpsr = irq_disable();
     cc110x_cs(dev);
     spi_transfer_byte(dev->params.spi, SPI_CS_UNDEF, false,
                       (addr | CC110X_READ_BURST));
@@ -108,33 +102,26 @@ void cc110x_readburst_reg(cc110x_t *dev, uint8_t addr, char *buffer, uint8_t cou
         i++;
     }
     gpio_set(dev->params.cs);
-    irq_restore(cpsr);
     spi_release(dev->params.spi);
 }
 
 void cc110x_write_reg(cc110x_t *dev, uint8_t addr, uint8_t value)
 {
-    unsigned int cpsr;
     lock(dev);
-    cpsr = irq_disable();
     cc110x_cs(dev);
     spi_transfer_reg(dev->params.spi, SPI_CS_UNDEF, addr, value);
     gpio_set(dev->params.cs);
-    irq_restore(cpsr);
     spi_release(dev->params.spi);
 }
 
 uint8_t cc110x_read_reg(cc110x_t *dev, uint8_t addr)
 {
     uint8_t result;
-    unsigned int cpsr;
     lock(dev);
-    cpsr = irq_disable();
     cc110x_cs(dev);
     result = spi_transfer_reg(dev->params.spi, SPI_CS_UNDEF,
                               (addr | CC110X_READ_SINGLE), CC110X_NOBYTE);
     gpio_set(dev->params.cs);
-    irq_restore(cpsr);
     spi_release(dev->params.spi);
     return result;
 }
@@ -142,14 +129,11 @@ uint8_t cc110x_read_reg(cc110x_t *dev, uint8_t addr)
 uint8_t cc110x_read_status(cc110x_t *dev, uint8_t addr)
 {
     uint8_t result;
-    unsigned int cpsr;
     lock(dev);
-    cpsr = irq_disable();
     cc110x_cs(dev);
     result = spi_transfer_reg(dev->params.spi, SPI_CS_UNDEF,
                               (addr | CC110X_READ_BURST), CC110X_NOBYTE);
     gpio_set(dev->params.cs);
-    irq_restore(cpsr);
     spi_release(dev->params.spi);
     return (uint8_t) result;
 }
@@ -157,9 +141,7 @@ uint8_t cc110x_read_status(cc110x_t *dev, uint8_t addr)
 uint8_t cc110x_get_reg_robust(cc110x_t *dev, uint8_t addr)
 {
     uint8_t res1, res2;
-    unsigned int cpsr;
     lock(dev);
-    cpsr = irq_disable();
     cc110x_cs(dev);
     do {
         res1 = spi_transfer_reg(dev->params.spi, SPI_CS_UNDEF,
@@ -168,7 +150,6 @@ uint8_t cc110x_get_reg_robust(cc110x_t *dev, uint8_t addr)
                                 (addr | CC110X_READ_BURST), CC110X_NOBYTE);
     } while (res1 != res2);
     gpio_set(dev->params.cs);
-    irq_restore(cpsr);
     spi_release(dev->params.spi);
     return res1;
 }
@@ -182,13 +163,10 @@ uint8_t cc110x_strobe(cc110x_t *dev, uint8_t c)
 #endif
 
     uint8_t result;
-    unsigned int cpsr;
     lock(dev);
-    cpsr = irq_disable();
     cc110x_cs(dev);
     result = spi_transfer_byte(dev->params.spi, SPI_CS_UNDEF, false,  c);
     gpio_set(dev->params.cs);
-    irq_restore(cpsr);
     spi_release(dev->params.spi);
     return result;
 }


### PR DESCRIPTION
The provided configuration for b-l475e-iot01a doesn't work, at least for UART, I haven't tested the SPI.
I couldn't find in the reference manual any information regarding the channel configuration. Maybe L4 are different from other STM32s ?

Otherwise, I think there was an issue with the SPI of b-l072z-lrwan1 (if I understand well the link between the reference manual the dma configuration...).

I also fixed the dma.c build when building for an L4 board.

Tomorrow, I'll have a look with F1/F2 and L1.

I rebased the branch on latest master, this is why the diff is huge. Just have a look at the 3 last commits.