### PR TITLE
mtd_spi_nor: Add actual wait timing to debug output

### DIFF
--- a/drivers/mtd_spi_nor/mtd_spi_nor.c
+++ b/drivers/mtd_spi_nor/mtd_spi_nor.c
@@ -272,6 +272,9 @@ static inline void wait_for_write_complete(const mtd_spi_nor_t *dev, uint32_t us
 {
     unsigned i = 0, j = 0;
     uint32_t div = 2;
+#if ENABLE_DEBUG && defined(MODULE_XTIMER)
+    uint32_t diff = xtimer_now_usec();
+#endif
     do {
         uint8_t status;
         mtd_spi_cmd_read(dev, dev->opcode->rdsr, &status, sizeof(status));
@@ -304,7 +307,18 @@ static inline void wait_for_write_complete(const mtd_spi_nor_t *dev, uint32_t us
         thread_yield();
 #endif
     } while (1);
-    DEBUG("wait loop %u times, yield %u times\n", i, j);
+#if ENABLE_DEBUG && defined(MODULE_XTIMER)
+    diff = xtimer_now_usec() - diff;
+#endif
+    DEBUG("wait loop %u times, yield %u times"
+#ifdef MODULE_XTIMER
+          ", total wait %"PRIu32"us"
+#endif
+          "\n", i, j,
+#ifdef MODULE_XTIMER
+          diff
+#endif
+          );
 }
 
 static int mtd_spi_nor_init(mtd_dev_t *mtd)


### PR DESCRIPTION
### Contribution description

While testing RIOT-OS/RIOT#9349 I found it very useful to have the actual wait timing in the debug output. This PR adds that output.

It got a bit complicated due to the optional dependency of `mtd_spi_nor` on xtimer.

### Issues/PRs references

RIOT-OS/RIOT#9349

In case you merge this into your current PR, feel free to squash this without retaining my authorship.

I can also submit this as a separate PR to RIOT if you don't want to further (potentially) delay your PR.