### PR TITLE
mtd_spi_nor: Move erase wait defines to struct

### DIFF
--- a/boards/mulle/board.c
+++ b/boards/mulle/board.c
@@ -61,6 +61,10 @@ static mtd_spi_nor_t mulle_nor_dev = {
     .addr_width = 3,
     .mode = SPI_MODE_3,
     .clk = SPI_CLK_10MHZ,
+    .wait_chip_erase = 16 * US_PER_SEC,
+    .wait_sector_erase = 40 * US_PER_MS,
+    .wait_32k_erase = 20 *US_PER_MS,
+    .wait_4k_erase = 10 * US_PER_MS,
 };
 
 mtd_dev_t *mtd0 = (mtd_dev_t *)&mulle_nor_dev;

--- a/drivers/include/mtd_spi_nor.h
+++ b/drivers/include/mtd_spi_nor.h
@@ -97,6 +97,11 @@ typedef struct {
     spi_clk_t clk;           /**< SPI clock */
     uint16_t flag;           /**< Config flags */
     mtd_jedec_id_t jedec_id; /**< JEDEC ID of the chip */
+    uint32_t wait_chip_erase; /**< Full chip erase wait time in µs */
+    uint32_t wait_sector_erase; /**< Sector erase wait time in µs */
+    uint32_t wait_32k_erase;    /**< 32KB page erase wait time in µs */
+    uint32_t wait_4k_erase;     /**< 4KB page erase wait time in µs */
+
     /**
      * @brief   bitmask to corresponding to the page address
      *

--- a/drivers/mtd_spi_nor/mtd_spi_nor.c
+++ b/drivers/mtd_spi_nor/mtd_spi_nor.c
@@ -49,22 +49,6 @@
 #define MTD_4K              (4096ul)
 #define MTD_4K_ADDR_MASK    (0xFFF)
 
-#ifndef MTD_SPI_NOR_WAIT_C_ER
-#define MTD_SPI_NOR_WAIT_C_ER       (16 * US_PER_SEC)
-#endif
-
-#ifndef MTD_SPI_NOR_WAIT_S_ER
-#define MTD_SPI_NOR_WAIT_S_ER       (40 * US_PER_MS)
-#endif
-
-#ifndef MTD_SPI_NOR_WAIT_32K_ER
-#define MTD_SPI_NOR_WAIT_32K_ER     (20 * US_PER_MS)
-#endif
-
-#ifndef MTD_SPI_NOR_WAIT_4K_ER
-#define MTD_SPI_NOR_WAIT_4K_ER      (10 * US_PER_MS)
-#endif
-
 static int mtd_spi_nor_init(mtd_dev_t *mtd);
 static int mtd_spi_nor_read(mtd_dev_t *mtd, void *dest, uint32_t addr, uint32_t size);
 static int mtd_spi_nor_write(mtd_dev_t *mtd, const void *src, uint32_t addr, uint32_t size);
@@ -487,7 +471,7 @@ static int mtd_spi_nor_erase(mtd_dev_t *mtd, uint32_t addr, uint32_t size)
         if (size == total_size) {
             mtd_spi_cmd(dev, dev->opcode->chip_erase);
             size -= total_size;
-            us = MTD_SPI_NOR_WAIT_C_ER;
+            us = dev->wait_chip_erase;
         }
         else if ((dev->flag & SPI_NOR_F_SECT_32K) && (size >= MTD_32K) &&
                  ((addr & MTD_32K_ADDR_MASK) == 0)) {
@@ -495,7 +479,7 @@ static int mtd_spi_nor_erase(mtd_dev_t *mtd, uint32_t addr, uint32_t size)
             mtd_spi_cmd_addr_write(dev, dev->opcode->block_erase_32k, addr_be, NULL, 0);
             addr += MTD_32K;
             size -= MTD_32K;
-            us = MTD_SPI_NOR_WAIT_32K_ER;
+            us = dev->wait_32k_erase;
         }
         else if ((dev->flag & SPI_NOR_F_SECT_4K) && (size >= MTD_4K) &&
                  ((addr & MTD_4K_ADDR_MASK) == 0)) {
@@ -503,13 +487,13 @@ static int mtd_spi_nor_erase(mtd_dev_t *mtd, uint32_t addr, uint32_t size)
             mtd_spi_cmd_addr_write(dev, dev->opcode->sector_erase, addr_be, NULL, 0);
             addr += MTD_4K;
             size -= MTD_4K;
-            us = MTD_SPI_NOR_WAIT_4K_ER;
+            us = dev->wait_4k_erase;
         }
         else {
             mtd_spi_cmd_addr_write(dev, dev->opcode->block_erase, addr_be, NULL, 0);
             addr += sector_size;
             size -= sector_size;
-            us = MTD_SPI_NOR_WAIT_S_ER;
+            us = dev->wait_sector_erase;
         }
 
         /* waiting for the command to complete before continuing */


### PR DESCRIPTION
### Contribution description

This PR moves the defines from RIOT-OS/RIOT#9349 to the `mtd_spi_nor_t` struct to be able to:

1. configure the timings per NOR flash chip.
2. Have it a bit more clear to the developer that these should be configured per board/chip.

### Issues/PRs references

RIOT-OS/RIOT#9349

In case you merge this into your current PR, feel free to squash this without retaining my authorship.

I can also submit this as a separate PR to RIOT if you don't want to further (potentially) delay your PR.